### PR TITLE
Add s3:PutObjectAcl to example permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ This is an example policy config which works:
         "s3:DeleteObject",
         "s3:ListBucket",
         "s3:PutObject",
+        "s3:PutObjectAcl",
         "s3:GetObject"
       ],
       "Resource": [


### PR DESCRIPTION
See https://github.com/EagerIO/Stout/blob/master/src/admin.go

This was missing in the README. Lead to a permission denied error on deploy